### PR TITLE
fix the escaping

### DIFF
--- a/PercentEncoder/PercentEncoding.swift
+++ b/PercentEncoder/PercentEncoding.swift
@@ -23,8 +23,19 @@ public enum PercentEncoding {
     }
     
     public func evaluate(string string: String) -> String {
-        // escape single quote becasue it is used in script string
-        let escaped = string.stringByReplacingOccurrencesOfString("'", withString: "\\'")
+        // escape back slash, single quote and line terminators because it is not included in ECMAScript SingleStringCharacter
+        var escaped = string
+        let mapping = [
+            "\\": "\\\\",
+            "'":  "\\'",
+            "\n": "\\n",
+            "\r": "\\r",
+            "\u{2028}": "\\u2028",
+            "\u{2029}": "\\u2029"]
+        for (src, dst) in mapping {
+            escaped = escaped.stringByReplacingOccurrencesOfString(src, withString: dst)
+        }
+        
         let script = "var value = \(functionName)('\(escaped)');"
         let context = JSContext()
         context.evaluateScript(script)

--- a/PercentEncoderTests/Constants.swift
+++ b/PercentEncoderTests/Constants.swift
@@ -12,4 +12,7 @@ struct Constants {
     static let input = "http://tasanobu.jp?city=東京&year='20"
     static let inputEscapedByEncodeURI = "http://tasanobu.jp?city=%E6%9D%B1%E4%BA%AC&year='20"
     static let inputEscapedByEncodeURIComponent = "http%3A%2F%2Ftasanobu.jp%3Fcity%3D%E6%9D%B1%E4%BA%AC%26year%3D'20"
+    
+    static let invalidJSString = "\\'\nabc\r123\u{2029}DEF\u{2028}大阪\r\n"
+    static let encodedInvalidJSString = "%5C'%0Aabc%0D123%E2%80%A9DEF%E2%80%A8%E5%A4%A7%E9%98%AA%0D%0A"
 }

--- a/PercentEncoderTests/PercentEncodingTests.swift
+++ b/PercentEncoderTests/PercentEncodingTests.swift
@@ -47,6 +47,13 @@ class PercentEncodingTests: XCTestCase {
         XCTAssertEqual(decoded, Constants.input, "")
     }
     
+    func testInvalidJSString() {
+        XCTAssertEqual(PercentEncoding.EncodeURI.evaluate(string: Constants.invalidJSString), Constants.encodedInvalidJSString)
+        XCTAssertEqual(PercentEncoding.EncodeURIComponent.evaluate(string: Constants.invalidJSString), Constants.encodedInvalidJSString)
+        XCTAssertEqual(PercentEncoding.DecodeURI.evaluate(string: Constants.encodedInvalidJSString), Constants.invalidJSString)
+        XCTAssertEqual(PercentEncoding.DecodeURIComponent.evaluate(string: Constants.encodedInvalidJSString), Constants.invalidJSString)
+    }
+    
     func testPerformanceExample() {
         // This is an example of a performance test case.
         self.measureBlock() {


### PR DESCRIPTION
If input string contains one of the \ or line terminators, the result become 'undefined'
