### PR TITLE
Support composed character sequences

### DIFF
--- a/PercentEncoder/PercentEncoding.swift
+++ b/PercentEncoder/PercentEncoding.swift
@@ -37,7 +37,7 @@ public enum PercentEncoding {
         var escaped = string
         
         for (src, dst) in mapping {
-            escaped = escaped.stringByReplacingOccurrencesOfString(src, withString: dst)
+            escaped = escaped.stringByReplacingOccurrencesOfString(src, withString: dst, options: .LiteralSearch)
         }
         
         let script = "var value = \(functionName)('\(escaped)');"

--- a/PercentEncoderTests/Constants.swift
+++ b/PercentEncoderTests/Constants.swift
@@ -15,4 +15,7 @@ struct Constants {
     
     static let invalidJSString = "\\'\nabc\r123\u{2029}DEF\u{2028}大阪\r\n"
     static let encodedInvalidJSString = "%5C'%0Aabc%0D123%E2%80%A9DEF%E2%80%A8%E5%A4%A7%E9%98%AA%0D%0A"
+    
+    static let composedCharacters = "(ه'́⌣'̀ه )"  // JS invalid charactor + combining character
+    static let encodedComposedCharacters = "(%D9%87'%CC%81%E2%8C%A3'%CC%80%D9%87%20)"
 }

--- a/PercentEncoderTests/PercentEncodingTests.swift
+++ b/PercentEncoderTests/PercentEncodingTests.swift
@@ -48,10 +48,21 @@ class PercentEncodingTests: XCTestCase {
     }
     
     func testInvalidJSString() {
-        XCTAssertEqual(PercentEncoding.EncodeURI.evaluate(string: Constants.invalidJSString), Constants.encodedInvalidJSString)
-        XCTAssertEqual(PercentEncoding.EncodeURIComponent.evaluate(string: Constants.invalidJSString), Constants.encodedInvalidJSString)
-        XCTAssertEqual(PercentEncoding.DecodeURI.evaluate(string: Constants.encodedInvalidJSString), Constants.invalidJSString)
-        XCTAssertEqual(PercentEncoding.DecodeURIComponent.evaluate(string: Constants.encodedInvalidJSString), Constants.invalidJSString)
+        let plain = Constants.invalidJSString
+        let encoded = Constants.encodedInvalidJSString
+        XCTAssertEqual(PercentEncoding.EncodeURI.evaluate(string: plain), encoded)
+        XCTAssertEqual(PercentEncoding.EncodeURIComponent.evaluate(string: plain), encoded)
+        XCTAssertEqual(PercentEncoding.DecodeURI.evaluate(string: encoded), plain)
+        XCTAssertEqual(PercentEncoding.DecodeURIComponent.evaluate(string: encoded), plain)
+    }
+    
+    func testComposedCharacters() {
+        let plain = Constants.composedCharacters
+        let encoded = Constants.encodedComposedCharacters
+        XCTAssertEqual(PercentEncoding.EncodeURI.evaluate(string: plain), encoded)
+        XCTAssertEqual(PercentEncoding.EncodeURIComponent.evaluate(string: plain), encoded)
+        XCTAssertEqual(PercentEncoding.DecodeURI.evaluate(string: encoded), plain)
+        XCTAssertEqual(PercentEncoding.DecodeURIComponent.evaluate(string: encoded), plain)
     }
     
     func testPerformanceExample() {


### PR DESCRIPTION
the result become 'undefined', If input string contains composed character sequence which base letter is one of \, ', and line separators.
